### PR TITLE
fix/patch4 update to Android Support Library 25.1.0 added new unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     //noinspection GroovyAssignabilityCheck,GroovyUntypedAccess
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 13 09:53:36 BST 2016
+#Fri Dec 09 10:02:17 GMT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/zapp-merchant-library/build.gradle
+++ b/zapp-merchant-library/build.gradle
@@ -1,15 +1,22 @@
 apply plugin: 'com.android.library'
 apply plugin: 'jacoco'
 
+ext {
+    PUBLISH_GROUP_ID = 'com.zapp.library'
+    PUBLISH_ARTIFACT_ID = 'merchant'
+    PUBLISH_VERSION = '1.0.4'
+}
+
+//noinspection GroovyMissingReturnStatement
 android {
-    compileSdkVersion 24
-    buildToolsVersion '23.0.3'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 24
-        versionCode 1003
-        versionName '1.0.3'
+        minSdkVersion 9
+        targetSdkVersion 25
+        versionCode 1004
+        versionName '1.0.4'
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -28,11 +35,13 @@ android {
 
 //noinspection GroovyUntypedAccess,GroovyAssignabilityCheck
 dependencies {
-    compile 'com.android.support:appcompat-v7:24.1.0'
-    compile 'com.android.support:support-annotations:24.1.0'
-    compile 'com.android.support:support-v4:24.1.0'
+    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:support-annotations:25.1.0'
+    compile 'com.android.support:support-v4:25.1.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test.espresso:espresso-intents:2.2.2'
 }
+
+apply from: 'release.gradle'

--- a/zapp-merchant-library/release.gradle
+++ b/zapp-merchant-library/release.gradle
@@ -1,0 +1,55 @@
+// ./gradlew clean build :zapp-merchant-library:generateLibraryRelease
+apply plugin: 'maven'
+
+def localReleaseDest = "${buildDir}/release/${version}"
+
+task javadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+afterEvaluate {
+    javadocs.classpath += files(android.libraryVariants.collect { variant ->
+        //noinspection GroovyUntypedAccess
+        variant.javaCompile.classpath.files
+    })
+}
+
+task javadocsJar(type: Jar, dependsOn: javadocs) {
+    classifier = 'javadoc'
+    from javadocs.destinationDir
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
+}
+
+uploadArchives {
+    repositories.mavenDeployer {
+        pom.groupId = project.PUBLISH_GROUP_ID
+        pom.artifactId = project.PUBLISH_ARTIFACT_ID
+        pom.version = project.PUBLISH_VERSION
+        // Add other pom properties here if you want (developer details / licenses)
+        repository(url: "file://${localReleaseDest}")
+    }
+}
+
+task zipRelease(type: Zip) {
+    from localReleaseDest
+    destinationDir buildDir
+    archiveName "release-${project.PUBLISH_VERSION}.zip"
+}
+
+task generateLibraryRelease << {
+    println "Release ${project.PUBLISH_VERSION} can be found at ${localReleaseDest}/"
+    println "Release ${project.PUBLISH_VERSION} zipped can be found ${buildDir}/release-${project.PUBLISH_VERSION}.zip"
+}
+
+generateLibraryRelease.dependsOn(uploadArchives)
+generateLibraryRelease.dependsOn(zipRelease)
+
+artifacts {
+    archives sourcesJar
+    archives javadocsJar
+}

--- a/zapp-merchant-library/src/androidTest/java/com/zapp/library/merchant/test/TestActivity.java
+++ b/zapp-merchant-library/src/androidTest/java/com/zapp/library/merchant/test/TestActivity.java
@@ -22,7 +22,7 @@ import android.support.v4.app.FragmentActivity;
  *
  * @author msagi
  */
-@SuppressWarnings("EmptyClass")
+@SuppressWarnings({"EmptyClass", "SuperClassHasFrequentlyUsedInheritors"})
 public class TestActivity extends FragmentActivity {
 
 }

--- a/zapp-merchant-library/src/androidTest/java/com/zapp/library/merchant/test/TestSuite.java
+++ b/zapp-merchant-library/src/androidTest/java/com/zapp/library/merchant/test/TestSuite.java
@@ -46,21 +46,25 @@ public class TestSuite {
     /**
      * Assert message.
      */
+    @SuppressWarnings("ConstantNamingConvention")
     public static final String ON_DISMISS_POPUP_CALLED_SHOULD_NOT_BE_CALLED = ".onDismissPopupCalled() should not be called";
 
     /**
      * Assert message.
      */
+    @SuppressWarnings("ConstantNamingConvention")
     public static final String ON_DISMISS_POPUP_CALLED_SHOULD_BE_CALLED = ".onDismissPopupCalled() should be called";
 
     /**
      * Assert message.
      */
+    @SuppressWarnings("ConstantNamingConvention")
     public static final String ON_RETRY_PAYMENT_REQUEST_SHOULD_NOT_BE_CALLED = ".onRetryPaymentRequest() should not be called";
 
     /**
      * Assert message.
      */
+    @SuppressWarnings("ConstantNamingConvention")
     public static final String ON_RETRY_PAYMENT_REQUEST_SHOULD_BE_CALLED = ".onRetryPaymentRequest() should be called";
 
     /**
@@ -73,6 +77,12 @@ public class TestSuite {
      * Constant (invalid: not 6 characters long) BRN code value.
      */
     public static final String INVALID_BRN = "BRN";
+
+    /**
+     * Constant with another valid BRN code value.
+     */
+    @SuppressWarnings("ConstantNamingConvention")
+    public static final String BRN2 = "BRN--2";
 
     /**
      * Constant secure token value.

--- a/zapp-merchant-library/src/androidTest/java/com/zapp/library/merchant/test/pbbaapputils/ShowPBBAErrorPopupTest.java
+++ b/zapp-merchant-library/src/androidTest/java/com/zapp/library/merchant/test/pbbaapputils/ShowPBBAErrorPopupTest.java
@@ -120,6 +120,17 @@ public class ShowPBBAErrorPopupTest {
     }
 
     @Test
+    public void testShowPBBAErrorPopupWithRetryCallbackOK() throws Exception {
+        final TestActivity activity = mActivityTestRule.getActivity();
+        PBBAAppUtils.showPBBAErrorPopup(/* fragmentActivity */ activity, TestSuite.ERROR_CODE, TestSuite.ERROR_TITLE, TestSuite.ERROR_MESSAGE, mCallback);
+        Assert.assertFalse(TestSuite.ON_RETRY_PAYMENT_REQUEST_SHOULD_NOT_BE_CALLED, mOnRetryPaymentRequestCalled);
+        Assert.assertFalse(TestSuite.ON_DISMISS_POPUP_CALLED_SHOULD_NOT_BE_CALLED, mOnDismissPopupCalled);
+        Espresso.onView(ViewMatchers.withId(R.id.pbba_button)).perform(ViewActions.click());
+        Assert.assertTrue(TestSuite.ON_RETRY_PAYMENT_REQUEST_SHOULD_BE_CALLED, mOnRetryPaymentRequestCalled);
+        Assert.assertFalse(TestSuite.ON_DISMISS_POPUP_CALLED_SHOULD_NOT_BE_CALLED, mOnDismissPopupCalled);
+    }
+
+    @Test
     public void testShowPBBAErrorPopupAndRotateOK() throws Exception {
         final TestActivity activity = mActivityTestRule.getActivity();
         PBBAAppUtils.showPBBAErrorPopup(/* fragmentActivity */ activity, TestSuite.ERROR_CODE, TestSuite.ERROR_TITLE, TestSuite.ERROR_MESSAGE, mCallback);

--- a/zapp-merchant-library/src/androidTest/java/com/zapp/library/merchant/test/pbbaapputils/ShowPBBAPopupTest.java
+++ b/zapp-merchant-library/src/androidTest/java/com/zapp/library/merchant/test/pbbaapputils/ShowPBBAPopupTest.java
@@ -181,4 +181,39 @@ public class ShowPBBAPopupTest {
 
         landscapeActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     }
+
+    @Test
+    public void testShowPBBAPopupTwiceSameBRN() throws Exception {
+
+        final TestActivity activity = mActivityTestRule.getActivity();
+        PBBAAppUtils.showPBBAPopup(/* fragmentActivity */ activity, TestSuite.SECURE_TOKEN, TestSuite.BRN, mCallback);
+
+        // Called to make sure we have the dialog fragment popped up before we continue to the next step, hence performing a click on a non-clickable logo-test-view
+        Espresso.onView(ViewMatchers.withId(R.id.pbba_popup_pay_by_bank_app_logo_text)).perform(ViewActions.click());
+        Assert.assertFalse(TestSuite.ON_RETRY_PAYMENT_REQUEST_SHOULD_NOT_BE_CALLED, mOnRetryPaymentRequestCalled);
+        Assert.assertFalse(TestSuite.ON_DISMISS_POPUP_CALLED_SHOULD_NOT_BE_CALLED, mOnDismissPopupCalled);
+
+        PBBAAppUtils.showPBBAPopup(/* fragmentActivity */ activity, TestSuite.SECURE_TOKEN, TestSuite.BRN, mCallback);
+        Espresso.onView(ViewMatchers.withId(R.id.pbba_popup_close)).perform(ViewActions.click());
+        Assert.assertFalse(TestSuite.ON_RETRY_PAYMENT_REQUEST_SHOULD_NOT_BE_CALLED, mOnRetryPaymentRequestCalled);
+        Assert.assertTrue(TestSuite.ON_DISMISS_POPUP_CALLED_SHOULD_BE_CALLED, mOnDismissPopupCalled);
+    }
+
+    @Test
+    public void testShowPBBAPopupTwiceDifferentBRN() throws Exception {
+
+        final TestActivity activity = mActivityTestRule.getActivity();
+        PBBAAppUtils.showPBBAPopup(/* fragmentActivity */ activity, TestSuite.SECURE_TOKEN, TestSuite.BRN, mCallback);
+
+        // Called to make sure we have the dialog fragment popped up before we continue to the next step, hence performing a click on a non-clickable logo-test-view
+        Espresso.onView(ViewMatchers.withId(R.id.pbba_popup_pay_by_bank_app_logo_text)).perform(ViewActions.click());
+        Assert.assertFalse(TestSuite.ON_RETRY_PAYMENT_REQUEST_SHOULD_NOT_BE_CALLED, mOnRetryPaymentRequestCalled);
+        Assert.assertFalse(TestSuite.ON_DISMISS_POPUP_CALLED_SHOULD_NOT_BE_CALLED, mOnDismissPopupCalled);
+
+        PBBAAppUtils.showPBBAPopup(/* fragmentActivity */ activity, TestSuite.SECURE_TOKEN, TestSuite.BRN2, mCallback);
+        Espresso.onView(ViewMatchers.withId(R.id.pbba_popup_close)).perform(ViewActions.click());
+        Assert.assertFalse(TestSuite.ON_RETRY_PAYMENT_REQUEST_SHOULD_NOT_BE_CALLED, mOnRetryPaymentRequestCalled);
+        Assert.assertTrue(TestSuite.ON_DISMISS_POPUP_CALLED_SHOULD_BE_CALLED, mOnDismissPopupCalled);
+    }
+
 }

--- a/zapp-merchant-library/src/main/java/com/zapp/library/merchant/util/PBBAAppUtils.java
+++ b/zapp-merchant-library/src/main/java/com/zapp/library/merchant/util/PBBAAppUtils.java
@@ -104,7 +104,7 @@ public final class PBBAAppUtils {
 
         final Uri zappUri = Uri.parse(String.format(ZAPP_URI_FORMAT_STRING, ZAPP_SCHEME, secureToken));
         final Intent bankingAppStartIntent = new Intent(Intent.ACTION_VIEW, zappUri);
-        final boolean isActivityContext = context instanceof Activity;
+        @SuppressWarnings("BooleanVariableAlwaysNegated") final boolean isActivityContext = context instanceof Activity;
         if (!isActivityContext) {
             bankingAppStartIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         }
@@ -240,7 +240,7 @@ public final class PBBAAppUtils {
      * @see #showPBBAPopup(FragmentActivity, String, String, PBBAPopupCallback)
      * @see #showPBBAErrorPopup(FragmentActivity, String, String, String, PBBAPopupCallback)
      */
-    @SuppressWarnings({"BooleanMethodNameMustStartWithQuestion", "ElementOnlyUsedFromTestCode"})
+    @SuppressWarnings({"BooleanMethodNameMustStartWithQuestion", "ElementOnlyUsedFromTestCode", "UnusedReturnValue"})
     public static boolean setPBBAPopupCallback(@NonNull final FragmentActivity activity, @NonNull final PBBAPopupCallback callback) {
 
         verifyActivity(activity);

--- a/zapp-merchant-library/src/main/java/com/zapp/library/merchant/util/PBBALibraryUtils.java
+++ b/zapp-merchant-library/src/main/java/com/zapp/library/merchant/util/PBBALibraryUtils.java
@@ -47,6 +47,7 @@ public final class PBBALibraryUtils {
     /**
      * The Pay by Bank app theme custom configuration key.
      */
+    @SuppressWarnings("WeakerAccess")
     public static final String KEY_PBBA_THEME = "pbbaTheme";
 
     /**
@@ -67,6 +68,7 @@ public final class PBBALibraryUtils {
     /**
      * The default value for Pay by Bank app theme.
      */
+    @SuppressWarnings("WeakerAccess")
     public static final int PBBA_THEME_DEFAULT_VALUE = PBBA_THEME_STANDARD;
 
     /**
@@ -91,7 +93,7 @@ public final class PBBALibraryUtils {
      *
      * @param properties The custom configuration to use.
      */
-    @SuppressWarnings({"MethodMayBeSynchronized", "ElementOnlyUsedFromTestCode"})
+    @SuppressWarnings({"MethodMayBeSynchronized", "ElementOnlyUsedFromTestCode", "SameParameterValue"})
     public static void setCustomConfiguration(@NonNull final Properties properties) {
         synchronized (PBBALibraryUtils.class) {
             //noinspection ConstantConditions


### PR DESCRIPTION
- Update to this release is optional.
- No changes in Merchant Library API
- The Merchant Library Documentation is updated (separate document).
- Distributed through jcenter (fix for the PBBAButton not rendering in Android Studio UI Editor)
- Compiled against latest Android API 25
- Updated to Android Support Library v25.1.0 (minimum required API changed from 8 to 9 due to this change)
- Updated Build Tools version from 23.0.3 to 25.0.2
- Gradle Tools updated from 2.2.0 to 2.2.2
- Gradle updated from 2.10 to 2.14.1
- Added new unit tests
- The Pay by Bank app Merchant Library for Android API documentation is available [here](https://vocalinkzapp.github.io/ZappMerchantLib-R2-Android/).
