### PR TITLE
fix/patch5

### DIFF
--- a/zapp-merchant-library/build.gradle
+++ b/zapp-merchant-library/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'jacoco'
 ext {
     PUBLISH_GROUP_ID = 'com.zapp.library'
     PUBLISH_ARTIFACT_ID = 'merchant'
-    PUBLISH_VERSION = '1.0.4'
+    PUBLISH_VERSION = '1.1.0'
 }
 
 //noinspection GroovyMissingReturnStatement
@@ -15,8 +15,8 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 25
-        versionCode 1004
-        versionName '1.0.4'
+        versionCode 1010
+        versionName '1.1.0'
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -30,14 +30,13 @@ android {
             minifyEnabled false
         }
     }
-
 }
 
 //noinspection GroovyUntypedAccess,GroovyAssignabilityCheck
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:support-annotations:25.1.0'
-    compile 'com.android.support:support-v4:25.1.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:support-annotations:25.3.1'
+    compile 'com.android.support:support-v4:25.3.1'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'

--- a/zapp-merchant-library/src/main/assets/pbbaCustomConfig.properties
+++ b/zapp-merchant-library/src/main/assets/pbbaCustomConfig.properties
@@ -9,3 +9,13 @@
 #   3: Barclays / Pay by Bank app co-branded dark theme and "Open Pingit" as button title on the m-Comm popup.
 #
 #pbbaTheme=1
+#
+# The CFI/Payment app name.
+#
+# Default value: 1.
+#
+# Options:
+#   1: "your mobile banking app"
+#   2: "Pingit"
+#
+#cfiAppName=1

--- a/zapp-merchant-library/src/main/java/com/zapp/library/merchant/ui/fragment/PBBAPopupFragment.java
+++ b/zapp-merchant-library/src/main/java/com/zapp/library/merchant/ui/fragment/PBBAPopupFragment.java
@@ -15,11 +15,6 @@
  */
 package com.zapp.library.merchant.ui.fragment;
 
-import com.zapp.library.merchant.R;
-import com.zapp.library.merchant.ui.PBBAPopupCallback;
-import com.zapp.library.merchant.util.PBBAAppUtils;
-import com.zapp.library.merchant.util.PBBALibraryUtils;
-
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
@@ -28,11 +23,18 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+
+import com.zapp.library.merchant.R;
+import com.zapp.library.merchant.ui.PBBAPopupCallback;
+import com.zapp.library.merchant.ui.view.CustomTextView;
+import com.zapp.library.merchant.util.PBBAAppUtils;
+import com.zapp.library.merchant.util.PBBALibraryUtils;
+
+import static com.zapp.library.merchant.util.PBBALibraryUtils.CFI_APP_NAME_DEFAULT;
 
 /**
  * Popup fragment for Zapp electronic and mobile commerce (e-Comm and m-Comm) journeys.
@@ -109,6 +111,34 @@ public final class PBBAPopupFragment extends PBBAPopup {
             onCreateECommView(content);
         }
 
+        final boolean useDefaultCfiAppName = PBBALibraryUtils.getCfiAppName(getContext()) == CFI_APP_NAME_DEFAULT;
+
+        final String cfiAppName = useDefaultCfiAppName ? getString(R.string.pbba_name) : getString(R.string.pingit);
+
+        CustomTextView openBankingAppCallToAction = (CustomTextView) content.findViewById(R.id.pbba_popup_open_banking_app_call_to_action);
+        if (openBankingAppCallToAction != null) {
+            openBankingAppCallToAction.setText(getString(R.string.pbba_popup_open_banking_app_call_to_action, cfiAppName));
+        }
+
+        CustomTextView payWithAnotherDeviceCallToAction = (CustomTextView) content.findViewById(R.id.pbba_popup_pay_with_another_device_call_to_action);
+        if (payWithAnotherDeviceCallToAction != null) {
+            payWithAnotherDeviceCallToAction.setText(getString(R.string.pbba_popup_pay_with_another_device_call_to_action, cfiAppName));
+        }
+
+        CustomTextView popupEcomItemTwoText = (CustomTextView) content.findViewById(R.id.pbba_popup_ecom_item_two_text);
+        if (popupEcomItemTwoText != null) {
+            popupEcomItemTwoText.setHtmlText(getString(R.string.pbba_popup_ecomm_item_two_text, cfiAppName));
+        }
+
+        final TextView openBankingAppButtonTitle = (TextView) content.findViewById(R.id.pbba_button_open_banking_app_text);
+        if (openBankingAppButtonTitle != null) {
+            if (useDefaultCfiAppName) {
+                openBankingAppButtonTitle.setText(getString(R.string.pbba_button_text_open_banking_app));
+            } else {
+                openBankingAppButtonTitle.setText(getString(R.string.pbba_button_text_open_banking_app_co_branded));
+            }
+        }
+
         //note: 'What is Pay by Bank app' link is set up in the parent class
 
         return content;
@@ -145,23 +175,6 @@ public final class PBBAPopupFragment extends PBBAPopup {
                 }
             }
         });
-
-        final int pbbaTheme = PBBALibraryUtils.getPbbaTheme(getContext());
-
-        final TextView buttonTitle = (TextView) openBankingAppButton.findViewById(R.id.pbba_button_open_banking_app_text);
-        switch (pbbaTheme) {
-            case PBBALibraryUtils.PBBA_THEME_STANDARD:
-                buttonTitle.setText(getString(R.string.pbba_button_text_open_banking_app));
-                break;
-            case PBBALibraryUtils.PBBA_THEME_PINGIT_LIGHT:
-            case PBBALibraryUtils.PBBA_THEME_PINGIT_DARK:
-                buttonTitle.setText(getString(R.string.pbba_button_text_open_banking_app_co_branded));
-                break;
-            default:
-                //nothing to do here as input validation happens during configuration file loading
-                Log.w(PBBALibraryUtils.PBBA_LOG_TAG, String.format("Unknown Pay by Bank app theme configuration: theme: %d", pbbaTheme));
-                break;
-        }
 
         final View getCodeButton = view.findViewById(R.id.pbba_button_get_code);
         if (getCodeButton != null) {

--- a/zapp-merchant-library/src/main/java/com/zapp/library/merchant/ui/view/CustomTextView.java
+++ b/zapp-merchant-library/src/main/java/com/zapp/library/merchant/ui/view/CustomTextView.java
@@ -15,17 +15,18 @@
  */
 package com.zapp.library.merchant.ui.view;
 
-import com.zapp.library.merchant.R;
-
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Typeface;
 import android.os.Build;
+import android.support.annotation.Nullable;
 import android.text.Html;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.widget.TextView;
+
+import com.zapp.library.merchant.R;
 
 /**
  * Custom text view for the Pay by Bank app popups.
@@ -84,17 +85,26 @@ public class CustomTextView extends TextView {
             setTypeface(customFont);
 
             final String htmlText = a.getString(R.styleable.CustomTextView_htmlText);
-            if (!TextUtils.isEmpty(htmlText)) {
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    setText(Html.fromHtml(htmlText, Html.FROM_HTML_MODE_LEGACY));
-                } else {
-                    //noinspection deprecation
-                    setText(Html.fromHtml(htmlText));
-                }
-            }
+            setHtmlText(htmlText);
         } finally {
             a.recycle();
+        }
+    }
+
+    /**
+     * Sets the string value of the TextView and applies the html format provided in the string.
+     *
+     * @param htmlText Text which contains html tags.
+     */
+    public void setHtmlText(@Nullable final String htmlText) {
+        if (!TextUtils.isEmpty(htmlText)) {
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                setText(Html.fromHtml(htmlText, Html.FROM_HTML_MODE_LEGACY));
+            } else {
+                //noinspection deprecation
+                setText(Html.fromHtml(htmlText));
+            }
         }
     }
 }

--- a/zapp-merchant-library/src/main/java/com/zapp/library/merchant/util/PBBALibraryUtils.java
+++ b/zapp-merchant-library/src/main/java/com/zapp/library/merchant/util/PBBALibraryUtils.java
@@ -47,8 +47,12 @@ public final class PBBALibraryUtils {
     /**
      * The Pay by Bank app theme custom configuration key.
      */
-    @SuppressWarnings("WeakerAccess")
     public static final String KEY_PBBA_THEME = "pbbaTheme";
+
+    /**
+     * The Pay by Bank app theme custom configuration key.
+     */
+    public static final String KEY_CFI_APP_NAME = "cfiAppName";
 
     /**
      * Standard PBBA theme value.
@@ -68,8 +72,22 @@ public final class PBBALibraryUtils {
     /**
      * The default value for Pay by Bank app theme.
      */
-    @SuppressWarnings("WeakerAccess")
     public static final int PBBA_THEME_DEFAULT_VALUE = PBBA_THEME_STANDARD;
+
+    /**
+     * The value identifier for PBBA app name.
+     */
+    public static final int CFI_APP_NAME_PBBA = 1;
+
+    /**
+     * The value identifier for Pingit app name.
+     */
+    public static final int CFI_APP_NAME_PINGIT = 2;
+
+    /**
+     * The default value identifier for CFI app name.
+     */
+    public static final int CFI_APP_NAME_DEFAULT = CFI_APP_NAME_PBBA;
 
     /**
      * Constant for banking app button clicked shared preferences key.
@@ -93,7 +111,7 @@ public final class PBBALibraryUtils {
      *
      * @param properties The custom configuration to use.
      */
-    @SuppressWarnings({"MethodMayBeSynchronized", "ElementOnlyUsedFromTestCode", "SameParameterValue"})
+    @SuppressWarnings({"MethodMayBeSynchronized", "ElementOnlyUsedFromTestCode"})
     public static void setCustomConfiguration(@NonNull final Properties properties) {
         synchronized (PBBALibraryUtils.class) {
             //noinspection ConstantConditions
@@ -103,14 +121,7 @@ public final class PBBALibraryUtils {
         }
     }
 
-    /**
-     * Get the Pay by Bank app theme setting.
-     *
-     * @param context The context to use.
-     * @return The theme value.
-     */
-    public static int getPbbaTheme(@NonNull final Context context) {
-        String pbbaThemeValue;
+    private static Properties getCustomConfiguration(@NonNull Context context) {
         synchronized (PBBALibraryUtils.class) {
             if (sCustomConfiguration == null) {
                 sCustomConfiguration = new Properties();
@@ -123,8 +134,19 @@ public final class PBBALibraryUtils {
                     //nothing to do here
                 }
             }
-            pbbaThemeValue = sCustomConfiguration.getProperty(KEY_PBBA_THEME);
         }
+        return sCustomConfiguration;
+    }
+
+    /**
+     * Get the Pay by Bank app theme setting.
+     *
+     * @param context The context to use.
+     * @return The theme value.
+     */
+    public static int getPbbaTheme(@NonNull final Context context) {
+
+        final String pbbaThemeValue = getCustomConfiguration(context).getProperty(KEY_PBBA_THEME);
 
         try {
             int theme = Integer.parseInt(pbbaThemeValue);
@@ -136,6 +158,22 @@ public final class PBBALibraryUtils {
             }
         } catch (NumberFormatException ignored) {
             return PBBA_THEME_DEFAULT_VALUE;
+        }
+    }
+
+    /**
+     * Get the CFI app name value identifier.
+     *
+     * @param context The context to use.
+     * @return The CFI app name value identifier.
+     */
+    public static int getCfiAppName(@NonNull final Context context) {
+        final String cfiAppNameValue = getCustomConfiguration(context).getProperty(KEY_CFI_APP_NAME);
+
+        try {
+            return Integer.parseInt(cfiAppNameValue);
+        } catch (NumberFormatException ignored) {
+            return CFI_APP_NAME_DEFAULT;
         }
     }
 
@@ -154,7 +192,7 @@ public final class PBBALibraryUtils {
      * Set the open banking app button clicked flag in shared preferences.
      *
      * @param context The context to use.
-     * @param value The new flag value.
+     * @param value   The new flag value.
      */
     public static void setOpenBankingAppButtonClicked(@NonNull final Context context, final boolean value) {
         final SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(context).edit().putBoolean(BANKING_APP_BTN_CLICKED, value);

--- a/zapp-merchant-library/src/main/res/values/strings_pbba.xml
+++ b/zapp-merchant-library/src/main/res/values/strings_pbba.xml
@@ -13,19 +13,23 @@
     <string name="pbba_button_text_open_banking_app_co_branded">Open Pingit</string>
     <string name="pbba_button_text_get_code_pre">Get\u0020\u0020</string>
 
+    <!--CFI app name-->
+    <string name="pingit">Pingit</string>
+    <string name="pbba_name">your mobile banking app</string>
+
     <!-- Pay by Bank app popup texts -->
     <string name="pbba_popup_what_is_pay_by_bank_app">What is Pay by Bank app? \u2192</string>
 
     <string name="pbba_popup_pay_on_this_device_title">Pay on this device</string>
-    <string name="pbba_popup_open_banking_app_call_to_action">Tap the button below to open your mobile banking app and log in to complete your purchase</string>
+    <string name="pbba_popup_open_banking_app_call_to_action">Tap the button below to open %s and log in to complete your purchase</string>
     <string name="pbba_popup_pay_with_another_device_title">Pay with another device</string>
-    <string name="pbba_popup_pay_with_another_device_call_to_action">Tap the button below if your mobile banking app is on another device</string>
+    <string name="pbba_popup_pay_with_another_device_call_to_action">Tap the button below if %s is on another device</string>
 
     <string name="pbba_popup_no_bank_app_message">None of the apps on this device currently support Pay by Bank app.</string>
     <string name="pbba_popup_submit_code_title">Follow the steps below to complete this purchase on another device:</string>
 
     <string name="pbba_popup_ecomm_item_one_text"><![CDATA[<b>Pick</b> up your phone or tablet]]></string>
-    <string name="pbba_popup_ecomm_item_two_text"><![CDATA[<b>Log in</b> to your mobile banking app]]></string>
+    <string name="pbba_popup_ecomm_item_two_text"><![CDATA[<b>Log in</b> to %s]]></string>
     <string name="pbba_popup_ecomm_item_three_text"><![CDATA[<b>Select</b> Pay by Bank app]]></string>
     <string name="pbba_popup_ecomm_item_four_text_one"><![CDATA[<b>Enter</b> the]]></string>
     <string name="pbba_popup_ecomm_item_four_text_two">\u0020below</string>


### PR DESCRIPTION
- No changes in Merchant Library API
- Added a new PBBA configuration key which makes the CFI app name displayed in the popup to be configurable.
- The Merchant Library Documentation is updated (separate document).
- Distributed through jcenter (fix for the PBBAButton not rendering in Android Studio UI Editor)
- Compiled against latest Android API 25
- Updated to Android Support Library v25.3.1
- The Pay by Bank app Merchant Library for Android API documentation is available [here](https://vocalinkzapp.github.io/ZappMerchantLib-R2-Android/).